### PR TITLE
feat(readme): add project setup instructions and roadmap

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,28 @@
+# A go server template
+
+## Create your new project
+
+Install gonew
+
+```sh
+go install golang.org/x/tools/cmd/gonew@latest
+```
+
+Create your new project
+
+```sh
+gonew github.com/tagpro/go-template <example.com/your.go-project.name>
+```
+
+## Roadmap
+
+- [ ] Add docker
+- [ ] Add healthcheck
+- [ ] Add logging
+- [ ] Add Tracing
+- [ ] Add Monitoring
+- [ ] Add OpenAPI
+
 ## Description
 
 This is a template for a go application that serves go APIs using chi router.


### PR DESCRIPTION
The changes in this commit add a new section to the README file that provides
instructions for setting up a new Go project using the `gonew` tool. It also
includes a roadmap of planned features to be added to the project template.
These changes aim to make it easier for developers to get started with this
project and understand the planned future development.