### PR TITLE
feat: Update config loading and server startup

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -3,6 +3,7 @@ package app
 import (
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/tagpro/go-template/internal/config"
 )
@@ -19,6 +20,6 @@ func NewServer(c *config.Config) (*Server, error) {
 
 func (s *Server) StartServer() error {
 	r := NewRouter()
-	log.Printf("Server listening on port %s", s.config.Port)
-	return http.ListenAndServe(":"+s.config.Port, r)
+	log.Printf("Server listening on port %d", s.config.Port)
+	return http.ListenAndServe(":"+strconv.Itoa(s.config.Port), r)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,38 +2,40 @@ package config
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/spf13/viper"
 	"github.com/tagpro/go-template/pkg/logger"
 )
 
 type Config struct {
-	Port   string
+	Port   int
 	Logger *logger.LogConfig
 }
 
 // LoadConfig loads config from file. You should be able to use env file for config as well.
 // The default config file is located at ./config/config.yaml.
 func LoadConfig() (*Config, error) {
+	config := &Config{
+		Port: 9000,
+		Logger: &logger.LogConfig{
+			Level:  slog.LevelDebug,
+			Format: "json",
+		},
+	}
+
 	viper.AddConfigPath("./config")
 	viper.SetConfigName("config")
 	err := viper.ReadInConfig()
 	if err != nil {
-		log.Println("config error: failed to load config: %w", err)
-		return nil, fmt.Errorf("config error: failed to load config: %w", err)
+		slog.Error("config error: failed to find config file", slog.Any("error", err))
+		slog.Info("continue with default config")
+		return config, nil
 	}
 
-	config := &Config{
-		Port: ":9000",
-		Logger: &logger.LogConfig{
-			Level:  0,
-			Format: "json",
-		},
-	}
 	err = viper.Unmarshal(config)
 	if err != nil {
-		log.Println("config error: failed to unmarshal config: %w", err)
+		slog.Error("config error: failed to unmarshal config", slog.Any("error", err))
 		return nil, fmt.Errorf("config error: failed to unmarshal config: %w", err)
 	}
 


### PR DESCRIPTION
This commit introduces the following changes:

- Modify the `Config` struct to use an `int` for the `Port` field instead of a `string`.
- Update the `LoadConfig` function to use the default configuration values if the config file is not found, and log the error instead of returning it.
- Replace the `log` package with the `slog` package for logging in the `LoadConfig` function.
- Update the `StartServer` function to convert the `Port` field to a string before passing it to `http.ListenAndServe`.

These changes improve the robustness and flexibility of the configuration loading and server startup processes.